### PR TITLE
os.ReadFile instead of ioutil.ReadFile and proper required binding

### DIFF
--- a/server/types/types.go
+++ b/server/types/types.go
@@ -1,7 +1,7 @@
 package types
 
 type RepoRequest struct {
-	Url string `json:"url,required"`
+	Url string `json:"url" binding:"required"`
 }
 
 type File struct {

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"offgit/types"
 	"os"
 	"strings"
@@ -42,7 +41,7 @@ func DirTree(path string) ([]*types.File, error) {
 			fileExts := strings.Split(f.Name(), ".")
 			extension := fileExts[len(fileExts)-1]
 			file.Extension = extension
-			content, err := ioutil.ReadFile(filePath)
+			content, err := os.ReadFile(filePath)
 			if err != nil {
 				fmt.Println(err.Error())
 			}


### PR DESCRIPTION
ioutil.ReadFile is deprecated, use os.ReadFile instead `(As of Go 1.16, this function simply calls os.ReadFile.)` from the documentation: https://pkg.go.dev/io/ioutil#ReadFile

gin uses validator under the `binding` struct tag, BTW there are tons of options that can be used to validate inputs for more info: https://github.com/go-playground/validator